### PR TITLE
Raise aha.AuthError to trigger reauthentication flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "contributes": {
       "importers": {
         "azure-devops": {
-          "title": "Azure Devops",
+          "title": "Azure DevOps",
           "entryPoint": "src/importers/azureDevopsImporter.js"
         }
       }

--- a/src/importers/azureDevops.js
+++ b/src/importers/azureDevops.js
@@ -8,12 +8,6 @@ class azureDevopsClient {
 
 export default azureDevopsClient;
 
-class AuthError extends Error {
-    constructor(message) {
-      super(message);
-    }
-}
-
 function getHeader() {
     return {
         'Authorization': "Bearer " + azureDevopsClient._token,
@@ -33,7 +27,7 @@ async function sendGetHttpRequest(endpoint, forWhat) {
     );
 
     if (!response.ok && response.status === 401) {
-        throw new AuthError(response.statusText);
+        throw new aha.AuthError(response.statusText, "ado");
     }
 
     const json = await response.json();
@@ -79,7 +73,7 @@ export async function getWorkItems(organization) {
     );
   
     if (!response.ok && response.status === 401) {
-      return false;
+      throw new aha.AuthError(response.statusText, "ado");
     }
   
     let json = await response.json();

--- a/src/importers/azureDevops.js
+++ b/src/importers/azureDevops.js
@@ -16,6 +16,16 @@ function getHeader() {
     }
 }
 
+function assertAuthenticated(response) {
+  if (!response.ok && response.status === 401) {
+    throw new aha.AuthError(response.statusText, "ado");
+  }
+
+  if (response.redirected && response.url.includes('signin')) {
+    throw new aha.AuthError(response.statusText, "ado");
+  }
+}
+
 
 async function sendGetHttpRequest(endpoint, forWhat) {
     const response = await fetch(
@@ -26,9 +36,7 @@ async function sendGetHttpRequest(endpoint, forWhat) {
         }
     );
 
-    if (!response.ok && response.status === 401) {
-        throw new aha.AuthError(response.statusText, "ado");
-    }
+    assertAuthenticated(response)
 
     const json = await response.json();
 
@@ -72,9 +80,7 @@ export async function getWorkItems(organization) {
       }
     );
   
-    if (!response.ok && response.status === 401) {
-      throw new aha.AuthError(response.statusText, "ado");
-    }
+    assertAuthenticated(response)
   
     let json = await response.json();
     if(json.workItems.length === 0) {


### PR DESCRIPTION
@jemmyw @percyhanna I believe this follows the pattern discussed yesterday. It seems to work as expected when I force this flow (i.e. `if (response.status === 200)`). Can you confirm that this is the intended way to trigger the reauth flow for importers?