### PR TITLE
Setup pagination in the azureDevops importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aha-develop.azure-devops-import",
   "description": "Azure DevOps Importer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Aha! (support@aha.io)",
   "repository": {
     "type": "git",

--- a/src/importers/azureDevops.js
+++ b/src/importers/azureDevops.js
@@ -1,4 +1,4 @@
-class azureDevopsClient {   
+class azureDevopsClient {
     static _token ;
 
     static setToken = (token) => {
@@ -54,7 +54,7 @@ async function sendGetHttpRequest(endpoint, forWhat) {
     return json.value;
 }
 
-export async function getOrganizationInfo(){       
+export async function getOrganizationInfo(){
     let endPoint = 'https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=6.0';
     let forWhat = 'userId';
     const userId = await sendGetHttpRequest(endPoint, forWhat);
@@ -66,11 +66,11 @@ export async function getOrganizationInfo(){
     return result;
 }
 
-export async function getWorkItems(organization) {  
+export async function getWorkItems(organization, offset) {
     const body = {
       "query": "Select  [System.Id], [System.Title], [System.State] From WorkItems"
     };
-  
+
     let response = await fetch(
       `https://dev.azure.com/${organization}/_apis/wit/wiql?api-version=5.1`,
       {
@@ -79,17 +79,18 @@ export async function getWorkItems(organization) {
         body:  JSON.stringify(body)
       }
     );
-  
+
     assertAuthenticated(response)
-  
+
     let json = await response.json();
-    if(json.workItems.length === 0) {
-      return "nothing";
+    const workItems = json.workItems.slice(offset, offset + 200);
+
+    if(workItems.length === 0) {
+      return { workItemList: "nothing", nextPageOffset: null };
     }
-  
-    const workitemsIdStr = json.workItems.map(workitem => workitem.id).join(",");  
+    const workitemsIdStr = workItems.map(workitem => workitem.id).join(",")
     const endPoint = `https://dev.azure.com/${organization}/_apis/wit/workitems?ids=${workitemsIdStr}&$expand=all&api-version=6.0`;
-    const result = await sendGetHttpRequest(endPoint, '');    
-    return result;
+    const result = await sendGetHttpRequest(endPoint, '');
+    return { workItemList: result, nextPageOffset: offset + workItems.length };
   }
 

--- a/src/importers/azureDevops.js
+++ b/src/importers/azureDevops.js
@@ -83,7 +83,7 @@ export async function getWorkItems(organization, offset) {
     assertAuthenticated(response)
 
     let json = await response.json();
-    const workItems = json.workItems.slice(offset, offset + 200);
+    const workItems = json.workItems.slice(offset, offset + 50);
 
     if(workItems.length === 0) {
       return { workItemList: "nothing", nextPageOffset: null };

--- a/src/importers/azureDevopsImporter.js
+++ b/src/importers/azureDevopsImporter.js
@@ -32,14 +32,13 @@ importer.on({ action: "filterValues" }, async ({ filterName, filters }, {identif
 
 importer.on({ action: "listCandidates" }, async ({ filters, nextPage }, {identifier, settings}) => {
   await authenticate();
-  const workItemList = await getWorkItems(filters.organization);
+  const { workItemList, nextPageOffset } = await getWorkItems(filters.organization, nextPage || 0);
   console.log(workItemList);
 
   if(workItemList == 'nothing') {
-    alert('There is no task to show.');
-    return { 
-      records: [] , 
-      nextPage: nextPage 
+    return {
+      records: [],
+      nextPage: nextPageOffset
     };
   }
 
@@ -51,19 +50,19 @@ importer.on({ action: "listCandidates" }, async ({ filters, nextPage }, {identif
         url: workItem._links.html.href,
         description: workItem.fields['System.Description']
       }));
-    
-      return { 
-        records: records , 
-        nextPage: nextPage 
+
+      return {
+        records: records ,
+        nextPage: nextPageOffset
       };
   }else{
     alert('The organization that you enter doesn\'t exist.');
-    return { 
-      records: [] , 
-      nextPage: nextPage 
+    return {
+      records: [] ,
+      nextPage: null
     };
   }
-  
+
 });
 
 importer.on({ action: "renderRecord" }, ({ record, onUnmounted }, { identifier, settings }) => {
@@ -76,7 +75,7 @@ importer.on({ action: "renderRecord" }, ({ record, onUnmounted }, { identifier, 
       <h6>{record.state}</h6>
       <a href={`${record.url}`}>{record.name}</a>
     </div>
-  );  
+  );
 });
 
 importer.on({ action: "importRecord" }, async ({ importRecord, ahaRecord }, {identifier, settings}) => {


### PR DESCRIPTION
When there are a large number of Workitems in an organization, it will try to put all of the IDs in the URL which can cause a failure. 

This PR will introduce pagination for the importer and will page through the items 200 at a time (which is the maximum as defined by the Azure API)